### PR TITLE
Fix laggy player movement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     git wget unzip \
     gcc g++ cmake make \
     xz-utils clang-format \
-    clang-tidy
+    clang-tidy nano
 
 # install protobuf
 RUN apt-get install -y \

--- a/src/common/ConnectionManager.hpp
+++ b/src/common/ConnectionManager.hpp
@@ -39,7 +39,6 @@ public:
 
   void disconnect() {
     if (not isConnected()) {
-      LOG_WRN("Connection already closed");
       return;
     }
     ::closeConnection(info->fd);


### PR DESCRIPTION
-Modify keyboard input handling so it doesn't rely on events which are slot and use 'sf::Keyboard::isKeyPressed' instead. Above was necessary as player may press/release keys very quickly and events mechanism isn't able to react in time though making visible delays.
More details can be found under following link:
https://www.sfml-dev.org/tutorials/3.0/window/inputs/

-Add nano text editor to Dockerfile so git can be used inside container

-Remove unnecessary warning in common/ConnectionManager.hpp